### PR TITLE
Package not in registry test fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # e2e-test-repo
 
-This repo is used for tests in https://github.com/yarnpkg/yarn/blob/master/__tests__/package-resolver.js
+This repo is used for tests in:
+
+- https://github.com/yarnpkg/yarn/blob/master/__tests__/package-resolver.js
+- https://github.com/juanca/yarn/blob/09d9a119e19867c459bfcce58de4ab37a4de5269/__tests__/commands/upgrade.js
+
 Don't delete it.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-test-git-repo",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
- [Related yarn pull request](https://github.com/yarnpkg/yarn/pull/2780)

Once this is in `master`, I can update the yarn PR to use `yarnpkg/e2e-test-repo#master`. It would be nice to keep this in a branch, however it seems I cannot make a PR for a non-existing branch. 

Though before that happens, I'd like to see a green CI build with `juanca/e2e-test-repo#package-not-in-registry`.

cc @bestander 